### PR TITLE
Adjust default settings to align with app settings.

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-BILLING_API_URL="http://localhost:8081"
-ORDER_API_URL="http://localhost:8082"
-SHIPMENT_API_URL="http://localhost:8083"
-FRAUD_API_URL="http://localhost:8084"
+BILLING_API_URL="http://127.0.0.1:8081"
+ORDER_API_URL="http://127.0.0.1:8082"
+SHIPMENT_API_URL="http://127.0.0.1:8083"
+FRAUD_API_URL="http://127.0.0.1:8084"


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adjust default settings 

## Why?

Align with default OMS app settings. On machines where localhost points at ipv6 loopback the web server would not be able to connect to the default app listeners, which are on ipv4.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
