### PR TITLE
update orders page to show progress

### DIFF
--- a/src/routes/orders/(order)/[id]/+page.server.ts
+++ b/src/routes/orders/(order)/[id]/+page.server.ts
@@ -1,6 +1,7 @@
 import { env } from '$env/dynamic/private';
 
-export const load = async ({ params }) => {
+export const load = async ({ params, depends }) => {
+	depends('data:order')
 	const { id } = params;
 
 	const orderResponse = await fetch(`${env.ORDER_API_URL}/orders/${id}`);

--- a/src/routes/orders/(order)/[id]/+page.svelte
+++ b/src/routes/orders/(order)/[id]/+page.svelte
@@ -1,9 +1,28 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
 	import FulfillmentDetails from '$lib/components/fulfillment-details.svelte';
 	import OrderActions from '$lib/components/order-actions.svelte';
 
 	$: ({ order } = $page.data);
+
+	onMount(() => {
+		const finalStatuses = ['completed', 'failed', 'cancelled'];
+
+		const interval = setInterval(() => {
+			const isFinal = finalStatuses.includes(order.status);
+			if (!isFinal) {
+				invalidate('data:order');
+			} else {
+				clearInterval(interval);
+			}
+		}, 500);
+
+		return () => {
+			clearInterval(interval);
+		};
+	});
 </script>
 
 <section>


### PR DESCRIPTION
## What was changed

Automatically update orders page to show progress without a manual page refresh.

## Why?

Demo was getting stuck showing `Pending` on the orders page and required a manual refresh with side-by-side windows for each role: customer and courier.

## Checklist
2. How was this tested:

MacOS 14.3.1 and Chrome 128.0.6613.114 (Official Build) (arm64)

3. Any docs updates needed?

Nope, it just auto refreshed now.