### PR TITLE
use workflow as exclusive source of truth for orders page

### DIFF
--- a/src/lib/components/shipment-status.svelte
+++ b/src/lib/components/shipment-status.svelte
@@ -2,13 +2,6 @@
 	export let id: string | undefined = undefined;
 	export let status = '';
 
-	if (id) {
-		const broadcaster = new BroadcastChannel(`shipment-${id}`);
-		broadcaster?.addEventListener('message', (event) => {
-			status = event.data;
-		});
-	}
-
 	const inactiveStatuses = ['pending', 'unavailable', 'cancelled', 'failed'];
 	const activeStatuses = ['booked', 'dispatched', 'delivered'];
 

--- a/src/routes/shipments/[id]/+page.svelte
+++ b/src/routes/shipments/[id]/+page.svelte
@@ -11,6 +11,18 @@
 	$: {
 		if (shipment?.id) {
 			broadcaster = new BroadcastChannel(`shipment-${shipment.id}`);
+
+			//note: the customer order page is polling for order status from the
+			//workflow itself since this courier shipping page is not the only
+			//source of workflow state changes
+			
+			//however to avoid polling on this this courier shipping page if
+			//multiple browser windows are open to the same shipping page we'd
+			//like those to be in sync, so will listen for events from a
+			//different browser window opened to the same shipping page
+			broadcaster?.addEventListener('message', (event) => {
+				status = event.data;
+			});
 		}
 	}
 


### PR DESCRIPTION
## What was changed

Use workflow state as exclusive source of truth for customer order detail page
- move shipment event listener from `ShipmentStatus` component to the courier shipment page
- remove shipment event listener from customer order details page (to avoid conflicting sources of truth)

## Why?

Shipment event listener in the order details page was causing a brief flickering of shipment status in the order detail.

2. How was this tested:

MacOS 14.3.1 and Chrome 128.0.6613.114 (Official Build) (arm64)

4. Any docs updates needed?

Nope