### PR TITLE
Remove unused shipment status 'id' field

### DIFF
--- a/src/lib/components/shipment-status.svelte
+++ b/src/lib/components/shipment-status.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	export const id: string | undefined = undefined;
 	export let status = '';
 
 	const inactiveStatuses = ['pending', 'unavailable', 'cancelled', 'failed'];

--- a/src/lib/components/shipment-status.svelte
+++ b/src/lib/components/shipment-status.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	export let id: string | undefined = undefined;
+	export const id: string | undefined = undefined;
 	export let status = '';
 
 	const inactiveStatuses = ['pending', 'unavailable', 'cancelled', 'failed'];


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I removed the shipment status ID.

## Why?
<!-- Tell your future self why have you made these changes -->

When testing a [PR #10](https://github.com/temporalio/reference-app-orders-web/pull/10/files), submitted by Phil Prasek, I found that Svelte issued a warning:

```
/Users/twheeler/projects/active/oms/reference-app-orders-web/src/lib/components/shipment-status.svelte:1:29 Shipment_status has unused export property 'id'. If it is for external reference only, please consider using `export const id`
```

One of the changes in that PR eliminated the use of the shipment status ID field. Since the field is no longer being used, this PR removes that field altogether.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
I observed the warning before the change. I made the change and then observed that the warning disappeared. In either case, I was able to successfully submit and process both single- and multi-item orders.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No