### PR TITLE
Load generator and simple monitoring UI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
 		"@sveltejs/adapter-node": "^5.0.1",
 		"@sveltejs/kit": "^2.8.3",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
+		"chart.js": "^4.4.8",
 		"svelte": "^4.2.19",
+		"svelte-chartjs": "^3.1.5",
 		"vite": "^5.4.12"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,15 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
         version: 3.0.0(svelte@4.2.19)(vite@5.4.12)
+      chart.js:
+        specifier: ^4.4.8
+        version: 4.4.8
       svelte:
         specifier: ^4.2.19
         version: 4.2.19
+      svelte-chartjs:
+        specifier: ^3.1.5
+        version: 3.1.5(chart.js@4.4.8)(svelte@4.2.19)
       vite:
         specifier: ^5.4.12
         version: 5.4.12
@@ -276,6 +282,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
 
   '@neoconfetti/svelte@1.0.0':
     resolution: {integrity: sha512-SmksyaJAdSlMa9cTidVSIqYo1qti+WTsviNDwgjNVm+KQ3DRP2Df9umDIzC4vCcpEYY+chQe0i2IKnLw03AT8Q==}
@@ -738,6 +747,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chart.js@4.4.8:
+    resolution: {integrity: sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==}
+    engines: {pnpm: '>=8'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1497,6 +1510,12 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svelte-chartjs@3.1.5:
+    resolution: {integrity: sha512-ka2zh7v5FiwfAX1oMflZ0HkNkgjHjFqANgRyC+vNYXfxtx2ku68Zo+2KgbKeBH2nS1ThDqkIACPzGxy4T0UaoA==}
+    peerDependencies:
+      chart.js: ^3.5.0 || ^4.0.0
+      svelte: ^4.0.0
+
   svelte-check@3.6.0:
     resolution: {integrity: sha512-8VfqhfuRJ1sKW+o8isH2kPi0RhjXH1nNsIbCFGyoUHG+ZxVxHYRKcb+S8eaL/1tyj3VGvWYx3Y5+oCUsJgnzcw==}
     hasBin: true
@@ -1839,6 +1858,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@kurkle/color@0.3.4': {}
 
   '@neoconfetti/svelte@1.0.0': {}
 
@@ -2252,6 +2273,10 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chart.js@4.4.8:
+    dependencies:
+      '@kurkle/color': 0.3.4
 
   chokidar@3.6.0:
     dependencies:
@@ -3032,6 +3057,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svelte-chartjs@3.1.5(chart.js@4.4.8)(svelte@4.2.19):
+    dependencies:
+      chart.js: 4.4.8
+      svelte: 4.2.19
 
   svelte-check@3.6.0(postcss-load-config@4.0.2(postcss@8.4.45))(postcss@8.4.45)(svelte@4.2.19):
     dependencies:

--- a/src/lib/server/load-generator/index.ts
+++ b/src/lib/server/load-generator/index.ts
@@ -1,0 +1,100 @@
+import { generateOrders } from '$lib/types/order';
+import { env } from '$env/dynamic/private';
+
+class LoadGenerator {
+  private running: boolean = false;
+  private orderInterval: number | null = null;
+  private pollInterval: number | null = null;
+
+  private config = {
+    ordersPerSecond: 1,
+    pollFrequency: 500, // How often to poll shipments (ms)
+  };
+
+  public start(config?: Partial<typeof this.config>) {
+    if (this.running) return;
+    this.running = true;
+
+    if (config) {
+      this.config = { ...this.config, ...config };
+    }
+
+    const orderDelay = 1000 / this.config.ordersPerSecond;
+    this.orderInterval = setInterval(() => this.createOrder(), orderDelay);
+    this.pollInterval = setInterval(() => this.pollShipments(), this.config.pollFrequency);
+
+    console.log('Load generator started');
+  }
+
+  public isRunning() {
+    return this.running;
+  }
+
+  public getConfig() {
+    return this.config;
+  }
+
+  // Stop the load generator
+  public stop() {
+    if (!this.running) return;
+    this.running = false;
+
+    if (this.orderInterval) {
+      clearInterval(this.orderInterval);
+      this.orderInterval = null;
+    }
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
+      this.pollInterval = null;
+    }
+
+    console.log('Load generator stopped');
+  }
+
+  private async createOrder() {
+    const order = generateOrders(1)[0];
+    try {
+      await fetch(`${env.ORDER_API_URL}/orders`, {
+          method: 'POST',
+          body: JSON.stringify(order),
+        });
+    } catch (error) {
+      console.error('Failed to create order:', error);
+    }
+  }
+
+  private async pollShipments() {
+    try {
+      const response = await fetch(`${env.SHIPMENT_API_URL}/shipments`);
+      const shipments = await response.json();
+
+      for (const shipment of shipments) {
+        if (shipment.status === 'completed') continue;
+
+        var next = "";
+
+        if (shipment.status === 'booked') {
+          next = 'dispatched';
+        } else if (shipment.status === 'dispatched') {
+          next = 'delivered';
+        }
+
+        if (next != '') {
+          try {
+            await fetch(`${env.SHIPMENT_API_URL}/shipments/${shipment.id}/status`, {
+              method: 'POST',
+              body: JSON.stringify({ status: next }),
+            });
+          } catch (error) {
+            console.error('Failed to update shipment status:', error);
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Failed to poll shipments:', error);
+    }
+  }
+}
+
+// Export singleton instance
+export const loadGenerator = new LoadGenerator();

--- a/src/routes/api/load-generator/+server.ts
+++ b/src/routes/api/load-generator/+server.ts
@@ -1,0 +1,20 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { loadGenerator } from '$lib/server/load-generator';
+
+export const POST: RequestHandler = async ({ request }) => {
+  const body = await request.json();
+  const { action, config } = body;
+
+  switch (action) {
+    case 'start':
+      loadGenerator.start(config);
+      return json({ running: true });
+
+    case 'stop':
+      loadGenerator.stop();
+      return json({ running: false });
+
+    default:
+      return json({ status: 'error' }, { status: 400 });
+  }
+}

--- a/src/routes/api/load-generator/status/+server.ts
+++ b/src/routes/api/load-generator/status/+server.ts
@@ -1,0 +1,9 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { loadGenerator } from '$lib/server/load-generator';
+
+export const GET: RequestHandler = async () => {
+  return json({ 
+    running: loadGenerator.isRunning(), 
+    config: loadGenerator.getConfig() 
+  });
+};

--- a/src/routes/api/order/stats/+server.ts
+++ b/src/routes/api/order/stats/+server.ts
@@ -1,0 +1,13 @@
+import { json } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+
+export const GET = async () => {
+    try {
+        const response = await fetch(`${env.ORDER_API_URL}/orders/stats`);
+        const { completeRate, backlog } = await response.json();
+        return json({ completeRate, backlog });
+    } catch (error) {
+        console.error('Failed to fetch backlog:', error);
+        return json(0, { status: 500 });
+    }
+};

--- a/src/routes/operator/+page.server.ts
+++ b/src/routes/operator/+page.server.ts
@@ -1,0 +1,5 @@
+export const load = async ({ fetch }) => {
+	const response = await fetch(`/api/load-generator/status`);
+	const { running, config } = await response.json();
+	return { running, config };
+};

--- a/src/routes/operator/+page.svelte
+++ b/src/routes/operator/+page.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { Line } from 'svelte-chartjs';
+	import { goto, invalidateAll } from '$app/navigation';
+	import {
+		Chart as ChartJS,
+		CategoryScale,
+		LinearScale,
+		PointElement,
+		LineElement,
+		Title,
+		Tooltip,
+		Legend
+	} from 'chart.js';
+
+	ChartJS.register(
+		CategoryScale,
+		LinearScale,
+		PointElement,
+		LineElement,
+		Title,
+		Tooltip,
+		Legend
+	);
+
+	export let data;
+
+	$: ({ running, config } = data);
+
+	let completeChartData = {
+		labels: [],
+		datasets: [
+			{
+				label: 'Order Complete RPS',
+				data: [],
+				borderColor: 'green',
+				tension: 0.1
+			},
+		]
+	};
+
+	let backlogChartData = {
+		labels: [],
+		datasets: [
+			{
+				label: 'Order Backlog',
+				data: [],
+				borderColor: 'red',
+				tension: 0.1
+			},
+		]
+	};
+
+	let refreshInterval: number;
+
+	const updateChartData = async() => {
+		const response = await fetch('/api/order/stats');
+		const { completeRate, backlog } = await response.json();
+
+		const now = new Date().toLocaleTimeString();
+
+		completeChartData.labels = [...completeChartData.labels.slice(-20), now];
+		backlogChartData.labels = [...backlogChartData.labels.slice(-20), now];
+		completeChartData.datasets[0].data = [...completeChartData.datasets[0].data.slice(-20), completeRate];
+		backlogChartData.datasets[0].data = [...backlogChartData.datasets[0].data.slice(-20), backlog];
+		chartData = chartData; // trigger reactivity
+	}
+
+	onMount(() => {
+			updateChartData();
+			refreshInterval = setInterval(updateChartData, 10000);
+	});
+
+	onDestroy(() => {
+			if (refreshInterval) clearInterval(refreshInterval);
+	});
+
+	const onStop = async () => {
+		await fetch('/api/load-generator', { method: 'POST', body: JSON.stringify({ action: 'stop' }) });
+		await invalidateAll();
+	};
+
+	const onStart = async () => {
+		await fetch('/api/load-generator', { method: 'POST', body: JSON.stringify({ action: 'start', config }) });
+		await invalidateAll();
+	};
+
+  const onToggle = async () => {
+    if (running) {
+      await onStop();
+    } else {
+      await onStart();
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-4 items-center justify-start">
+	<h1>Operator</h1>
+	<div class="flex gap-2 w-full">
+		<div class="w-full p-4 flex flex-col gap-4 bg-white border border-black rounded">
+			<h3 class="text-xl font-bold">Load Testing</h3>
+			<p>
+				Orders per second: <strong>{config.ordersPerSecond}</strong>
+			</p>
+			<p>
+				Status: <strong>{running ? 'Running' : 'Stopped'}</strong>
+			</p>
+			<div class="flex items-center gap-2">
+				<input type="number" bind:value={config.ordersPerSecond} class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" />
+				<button on:click={onToggle} class="w-full text-nowrap">{running ? 'Stop' : 'Start'}</button>
+			</div>
+		</div>
+	</div>
+	<div class="flex gap-2 w-full">
+		<div class="w-full p-4 flex flex-col gap-4 bg-white border border-black rounded">
+			<h3 class="text-xl font-bold">Order Completions</h3>
+			<div class="w-full h-[300px]">
+				<Line 
+						data={completeChartData}
+						options={{
+								responsive: true,
+								maintainAspectRatio: false,
+								animation: false,
+								scales: {
+									y: {
+										beginAtZero: true
+									}
+								}
+						}}
+					/>
+				</div>
+			</div>
+			<div class="w-full p-4 flex flex-col gap-4 bg-white border border-black rounded">
+				<h3 class="text-xl font-bold">Order Backlog</h3>
+				<div class="w-full h-[300px]">
+					<Line 
+					data={backlogChartData}
+					options={{
+							responsive: true,
+							maintainAspectRatio: false,
+							animation: false,
+							scales: {
+								y: {
+									beginAtZero: true
+								}
+							}
+					}}
+				/>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/routes/usertype/+page.svelte
+++ b/src/routes/usertype/+page.svelte
@@ -28,6 +28,9 @@
 				<td><a href="/admin">Store Manager</a></td>
 				<td>Someone who performs administrative functions</td>
 			</tr>
+			<tr>
+				<td><a href="/operator">Operator</a></td>
+				<td>Someone who manages deployments and tests the system's performance</td>
 		</tbody>
 	</table>
 


### PR DESCRIPTION
This is to make it easy for users to run simple load tests and see how things perform. Ideally this will be complemented by a prometheus (or similar) setup to have full access to our metrics.

However, I've added a simple stats endpoint to the main application API in https://github.com/temporalio/reference-app-orders-go/pull/87 so that we can at least show some monitoring in the UI itself without needing the user to deploy and configure the metrics system.
