### PR TITLE
updated Svelte kit and adapter-node libraries and specified explicit dependency on devalue

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,13 @@
 	"dependencies": {
 		"@fontsource/fira-mono": "^4.5.10",
 		"@neoconfetti/svelte": "^1.0.0",
-		"@sveltejs/adapter-node": "^5.0.1",
-		"@sveltejs/kit": "^2.20.6",
+		"@sveltejs/adapter-node": "^5.2.12",
+		"@sveltejs/kit": "^2.20.7",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",
 		"@tailwindcss/vite": "^4.1.4",
 		"chart.js": "^4.4.8",
 		"svelte": "^5.28.2",
+		"devalue": "^5.3.2",
 		"tailwindcss": "^4.1.4",
 		"vite": "^5.4.16"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,10 +15,10 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       '@sveltejs/adapter-node':
-        specifier: ^5.0.1
+        specifier: ^5.2.12
         version: 5.2.12(@sveltejs/kit@2.20.7(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.18(lightningcss@1.29.2)))(svelte@5.28.2)(vite@5.4.18(lightningcss@1.29.2)))
       '@sveltejs/kit':
-        specifier: ^2.20.6
+        specifier: ^2.20.7
         version: 2.20.7(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.18(lightningcss@1.29.2)))(svelte@5.28.2)(vite@5.4.18(lightningcss@1.29.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.0-next.6
@@ -29,6 +29,9 @@ importers:
       chart.js:
         specifier: ^4.4.8
         version: 4.4.9
+      devalue:
+        specifier: ^5.3.2
+        version: 5.3.2
       svelte:
         specifier: ^5.28.2
         version: 5.28.2
@@ -791,8 +794,8 @@ packages:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
 
-  devalue@5.1.1:
-    resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
+  devalue@5.3.2:
+    resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1861,7 +1864,7 @@ snapshots:
       '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.28.2)(vite@5.4.18(lightningcss@1.29.2))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
-      devalue: 5.1.1
+      devalue: 5.3.2
       esm-env: 1.2.2
       import-meta-resolve: 4.1.0
       kleur: 4.1.5
@@ -2193,7 +2196,7 @@ snapshots:
 
   detect-libc@2.0.4: {}
 
-  devalue@5.1.1: {}
+  devalue@5.3.2: {}
 
   dir-glob@3.0.1:
     dependencies:


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
I updated Svelte kit and adapter-node libraries and specified explicit dependency on devalue

## Why?
<!-- Tell your future self why have you made these changes -->

This should hopefully address a [high-severity dependabot alert](https://github.com/temporalio/reference-app-orders-web/security/dependabot/20) opened a few hours ago.

## Checklist

1. Closes 

https://github.com/temporalio/reference-app-orders-web/security/dependabot/20

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

After making the changes, I ran `pnpm into && pnpm dev` and then processed an order to completion. I then looked at `node_modules/devalue/package.json` and verified that the devalue library was version 5.3.2, which dependabot specifies contains the fix.

3. Any docs updates needed?

No
